### PR TITLE
AV-599: Ease policy if fallback title exists

### DIFF
--- a/ios/RNSensitiveInfo/RNSensitiveInfo.m
+++ b/ios/RNSensitiveInfo/RNSensitiveInfo.m
@@ -181,7 +181,10 @@ RCT_EXPORT_METHOD(getItem:(NSString *)key options:(NSDictionary *)options resolv
             prompt = [RCTConvert NSString:options[@"kSecUseOperationPrompt"]];
         }
         
-        [context evaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics
+        // If kLocalizedFallbackTitle exist, LAPolicy must allow fallback to pin also
+        NSInteger policy = kLocalizedFallbackTitle ? LAPolicyDeviceOwnerAuthentication : LAPolicyDeviceOwnerAuthenticationWithBiometrics;
+        
+        [context evaluatePolicy:policy
                 localizedReason:prompt
                           reply:^(BOOL success, NSError * _Nullable error) {
                               if (!success) {


### PR DESCRIPTION
So sorry all.

I missed a pretty major bug with this change.  Fixed here.

If the fallback title exist, we need to ease to authentication policy to allow pin fallback....

```
    /// @discussion Biometric authentication is required. If the biometry is not available, not enrolled,
    ///             or locked out, then the evaluation of this policy will fail with LAErrorBiometryNotAvailable,
    ///             LAErrorBiometryNotEnrolled or LAErrorBiometryLockout. Biometry can't be used without a passcode,
    ///             i.e. when biometry is available, enrolled and not locked out but passcode is not set, then
    ///             the evaluation will fail with LAErrorPasscodeNotSet.
    ///
    ///             Touch ID authentication dialog contains a cancel button with default title "Cancel"
    ///             which can be customized using localizedCancelTitle property, and a fallback button with
    ///             default title "Enter Password" which can be customized using localizedFallbackTitle
    ///             property. Fallback button is initially hidden and shows up after first unsuccessful
    ///             Touch ID attempt. Tapping either button causes evaluatePolicy call to fail, returning
    ///             a distinct error code: LAErrorUserCancel or LAErrorUserFallback.
    ///
    ///             Face ID authentication begins with animating HUD. If it succeeds at first attempt,
    ///             the HUD will disappear and no other UI is shown. If the first attempt fails, then
    ///             LocalAuthentication will show a dialog with two buttons: "Cancel" and "Try Face ID Again".
    ///             After second failure, the buttons are "Cancel" and "Enter Password" with the same
    ///             semantics as in the case of Touch ID.
    ///
    ///             Biometric authentication will get locked after 5 unsuccessful attempts. After that,
    ///             users have to unlock it by entering passcode. The passcode can be entered either at
    ///             Lock Screen or even in app by the means of LAPolicyDeviceOwnerAuthentication.
    ///             The Lock Screen unlock is preferred user experience because we generaly don't want users to
    ///             enter their passcode at app's request.
    LAPolicyDeviceOwnerAuthenticationWithBiometrics API_AVAILABLE(ios(8.0), macos(10.12.2), watchos(3.0), tvos(10.0)) = kLAPolicyDeviceOwnerAuthenticationWithBiometrics,
```

```
    /// @discussion Biometric or passcode authentication is required. If the biometry is available, enrolled and
    ///             not locked out, users are asked for it first. Otherwise they are asked to enter device
    ///             passcode. If passcode is not enabled, policy evaluation will fail with LAErrorPasscodeNotSet.
    ///
    ///             Biometric authentication dialog behaves similarly as the one used by
    ///             LAPolicyDeviceOwnerAuthenticationWithBiometrics. However, instead of "Enter Password"
    ///             button there is "Enter Passcode" button which, when tapped, switches the authentication
    ///             method and allows users to enter device passcode.
    ///
    ///             Passcode authentication will get locked after 6 unsuccessful attempts with progressively
    ///             increased backoff delay.
    LAPolicyDeviceOwnerAuthentication API_AVAILABLE(ios(9.0), macos(10.11), watchos(3.0), tvos(10.0)) = kLAPolicyDeviceOwnerAuthentication,
```